### PR TITLE
Fix a bug in a bug fix and make tests pass with future and current versions of DateTime::Locale

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,9 @@ Revision history for Perl module DateTime::Format::CLDR
     - Fix incorrect interpretation of hour "24" for the k patterns. This
       should be treated as equivalent to "00", not as "00" _on the next
       day_ (Fixed by Dave Rolsky)
+    - Make all tests pass with both the current DateTime::Locale and the
+      upcoming new version (currently still in trial releases) (fixed by Dave
+      Rolsky)
 
 1.15 Thi Aug 15 2013
     - Fix failing tests

--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for Perl module DateTime::Format::CLDR
 
+    - Fix incorrect interpretation of hour "24" for the k patterns. This
+      should be treated as equivalent to "00", not as "00" _on the next
+      day_ (Fixed by Dave Rolsky)
+
 1.15 Thi Aug 15 2013
     - Fix failing tests
     - Fix bad parsing of HH:mm:ss -> 24:00:00, rt87550 (reported by Gonzalo Mateo)

--- a/lib/DateTime/Format/CLDR.pm
+++ b/lib/DateTime/Format/CLDR.pm
@@ -690,7 +690,6 @@ sub parse_datetime {
         $datetime{hour} = $datetime_info{hour24};
         if ($datetime{hour} == 24) {
             $datetime{hour} = 0;
-            $datetime_info{dayadd} = 1;
         }
     }
     
@@ -1233,7 +1232,8 @@ The hour from 0-11.
 
 =item * k{1,2}
 
-The hour from 1-24.
+The hour from 1-24. Note that hour 24 is equivalent to midnight on the date
+being parsed, not midnight of the next day.
 
 =item * j{1,2}
 

--- a/t/004_basic.t
+++ b/t/004_basic.t
@@ -18,7 +18,7 @@ my $cldr = DateTime::Format::CLDR->new(
 is($cldr->incomplete,1,'incomplete accessor');
 is($cldr->on_error,'undef','on_error accessor');
 isa_ok($cldr,'DateTime::Format::CLDR');
-isa_ok($cldr->locale,'DateTime::Locale::de_AT');
+like($cldr->locale->id,qr/de[_\-]AT/,'DateTime::Locale id is de-AT');
 isa_ok($cldr->time_zone,'DateTime::TimeZone::Floating');
 
 $cldr->time_zone(DateTime::TimeZone::UTC->new);
@@ -27,16 +27,16 @@ isa_ok($cldr->time_zone,'DateTime::TimeZone::UTC','Timezone has been set');
 
 $cldr->locale(DateTime::Locale->load( 'de_DE' ));
 
-isa_ok($cldr->locale,'DateTime::Locale::de_DE','Locale has been set');
+like($cldr->locale->id,qr/de[_\-]DE/,'Locale has been set');
 
-is($cldr->pattern,'dd.MM.yyyy','Pattern set ok');
+like($cldr->pattern,qr/dd.MM.y(?:yyy){0,1}/,'Pattern set ok');
 
 my $datetime = $cldr->parse_datetime('22.11.2011');
 
 isa_ok($datetime,'DateTime');
 is($datetime->dmy,'22-11-2011','String has been parsed');
 isa_ok($datetime->time_zone,'DateTime::TimeZone::UTC','String has correct timezone');
-isa_ok($datetime->locale,'DateTime::Locale::de_DE','String has correct locale');
+like($datetime->locale->id,qr/de[_\-]DE/,'Locale has been set');
 
 $cldr->pattern('dd.MMMM.yyyy');
 

--- a/t/006_exceptions.t
+++ b/t/006_exceptions.t
@@ -16,7 +16,7 @@ my $cldr = DateTime::Format::CLDR->new();
 
 throws_ok { 
     $cldr->locale('xx');
-} qr/Invalid locale name or id: xx/;
+} qr/Invalid locale (?:name or id|code or name): xx/;
 
 throws_ok { 
     $cldr->time_zone('+9999');

--- a/t/015_synopsis.t
+++ b/t/015_synopsis.t
@@ -52,7 +52,7 @@ like($@,qr/23\.33\.2007/,'Error message ok');
 # Use DateTime::Locale
 my $locale4 = DateTime::Locale->load('en_GB');
 my $cldr4 = DateTime::Format::CLDR->new(
-    pattern     => $locale4->datetime_format_medium,
+    pattern     => 'd MMM y HH:mm:ss',
     locale      => $locale4,
 );
 

--- a/t/018_bug_rt89846.t
+++ b/t/018_bug_rt89846.t
@@ -23,8 +23,8 @@ my $fc = DateTime::Format::CLDR->new(
 );
 
 is($fc->parse_datetime('2013.07.21 23:00:00')->iso8601,'2013-07-21T23:00:00','23:00:00 parsed ok');
-is($fc->parse_datetime('2013.07.21 24:00:00')->iso8601,'2013-07-22T00:00:00','24:00:00 parsed ok');
-is($fc->parse_datetime('2013.07.21 24:30:00')->iso8601,'2013-07-22T00:30:00','24:30:00 parsed ok');
+is($fc->parse_datetime('2013.07.21 24:00:00')->iso8601,'2013-07-21T00:00:00','24:00:00 parsed ok');
+is($fc->parse_datetime('2013.07.21 24:30:00')->iso8601,'2013-07-21T00:30:00','24:30:00 parsed ok');
 is($fc->parse_datetime('2013.07.22 01:00:00')->iso8601,'2013-07-22T01:00:00','01:00:00 parsed ok');
 
 


### PR DESCRIPTION
This PR contains two changes:

First, the handling of "24" in a "kk" pattern was incorrectly changed in a previous release. I did some painful testing with libicu's C++ code and confirmed that for `2015-02-01T00:05:00`, the pattern `yyyy-MM-dd 'at' kk:mm:ss a` outputs `2015-02-01 at 24:05:00 AM`. The date **does not roll over**.

The other fix is to accommodate changes coming in future version of DateTime::Locale. These changes make the tests pass with both the current stable release and the trial releases.