### PR TITLE
nanosecs pattern can contain 9 or less significant signs

### DIFF
--- a/t/011_nanosecond.t
+++ b/t/011_nanosecond.t
@@ -18,7 +18,7 @@ explain("This test might fail on some plattforms due to unknown reasons");
 
 my $dtf1 = DateTime::Format::CLDR->new(
     locale      => 'en_US',
-    pattern     => 'dd.MM.yyy HH:mm:ss.SSSSSSSSSSSSSS',
+    pattern     => 'dd.MM.yyy HH:mm:ss.SSSSSSSSS',
 );
 
 my $dtf2 = DateTime::Format::CLDR->new(


### PR DESCRIPTION
Prefix `nano` means 10^-9, so pattern must have 9 `S` maximum. You use 14 symbols and that's why this test fails.

